### PR TITLE
Ensure the sub-process exits before the parent process by removing th…

### DIFF
--- a/src/createExecute.ts
+++ b/src/createExecute.ts
@@ -60,7 +60,6 @@ export const createExecute =
                 });
             });
 
-            shell.unref();
             shell = null;
         });
     };


### PR DESCRIPTION
…e unref call

by using unref, we were introducing a race condition between the parent process exiting and the sub-process exiting - by removing the unref we also remove the race condition as the sub-process will cause the parent process to stay active whilst the sub-process is active. This is likely the correct approach we want to take, if a sub-process is hanging, that is likely an issue the project using cli-testing-library will want to fix as it shows the test is not actually working as they expect it to.