### PR TITLE
Use fs.rm instead of the deprecated fs.rmdir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export const prepareEnvironment = async (): Promise<CLITestEnvironment> => {
             task.current = null;
         });
 
-        await fsRemoveDir(tempDir, { recursive: true });
+        await fsRemove(tempDir, { recursive: true });
     };
 
     try {


### PR DESCRIPTION
This resolves the deprecation warning:
>(node:42009) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead